### PR TITLE
Use ROOT locale for toLowerCase

### DIFF
--- a/src/main/java/com/grimbo/chipped/api/ChippedWoodType.java
+++ b/src/main/java/com/grimbo/chipped/api/ChippedWoodType.java
@@ -1,5 +1,7 @@
 package com.grimbo.chipped.api;
 
+import java.util.Locale;
+
 public enum ChippedWoodType {
     OAK, BIRCH, SPRUCE, JUNGLE, ACACIA, DARK_OAK, WARPED, CRIMSON;
 
@@ -7,6 +9,6 @@ public enum ChippedWoodType {
 
     @Override
     public String toString() {
-        return name().toLowerCase();
+        return name().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/grimbo/chipped/block/ChippedWorkbench.java
+++ b/src/main/java/com/grimbo/chipped/block/ChippedWorkbench.java
@@ -34,6 +34,8 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.registries.ForgeRegistries;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Locale;
+
 public class ChippedWorkbench extends Block {
     public static final DirectionProperty FACING = HorizontalBlock.FACING;
 
@@ -170,7 +172,7 @@ public class ChippedWorkbench extends Block {
 
         @Override
         public String getSerializedName() {
-            return name().toLowerCase();
+            return name().toLowerCase(Locale.ROOT);
         }
 
         @Override


### PR DESCRIPTION
Fixes https://github.com/WillowWorks/Chipped/issues/77

To test, add this to `minecraft.runs.client` in `build.gradle` and run `./gradlew runClient`:

```gradle
property 'user.language', 'tr'
property 'user.country', 'TR'
```

With the fix, the game starts up correctly.