### PR TITLE
Update JEI and add a scrolling ingredient grid for showing recipes

### DIFF
--- a/common/src/main/java/earth/terrarium/chipped/common/compat/jei/ChippedJeiPlugin.java
+++ b/common/src/main/java/earth/terrarium/chipped/common/compat/jei/ChippedJeiPlugin.java
@@ -10,6 +10,8 @@ import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -30,20 +32,24 @@ public class ChippedJeiPlugin implements IModPlugin {
 
     @Override
     public void registerRecipes(IRecipeRegistration registration) {
-        Objects.requireNonNull(Minecraft.getInstance().level).getRecipeManager()
-            .getAllRecipesFor(ModRecipeTypes.WORKBENCH.get()).forEach(recipe ->
-                recipe.value().ingredients().forEach(ingredient ->
-                    registration.addRecipes(WorkbenchCategory.RECIPE, List.of(ingredient))));
+        RecipeManager recipeManager = Objects.requireNonNull(Minecraft.getInstance().level).getRecipeManager();
+        recipeManager.getAllRecipesFor(ModRecipeTypes.WORKBENCH.get())
+            .forEach(recipe -> {
+                List<Ingredient> ingredients = recipe.value().ingredients();
+                registration.addRecipes(WorkbenchCategory.RECIPE, ingredients);
+            });
     }
 
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
-        registration.addRecipeCatalyst(ModItems.BOTANIST_WORKBENCH.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
-        registration.addRecipeCatalyst(ModItems.GLASSBLOWER.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
-        registration.addRecipeCatalyst(ModItems.CARPENTERS_TABLE.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
-        registration.addRecipeCatalyst(ModItems.LOOM_TABLE.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
-        registration.addRecipeCatalyst(ModItems.MASON_TABLE.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
-        registration.addRecipeCatalyst(ModItems.ALCHEMY_BENCH.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
-        registration.addRecipeCatalyst(ModItems.TINKERING_TABLE.get().getDefaultInstance(), WorkbenchCategory.RECIPE);
+        registration.addRecipeCatalysts(WorkbenchCategory.RECIPE,
+            ModItems.BOTANIST_WORKBENCH.get(),
+            ModItems.GLASSBLOWER.get(),
+            ModItems.CARPENTERS_TABLE.get(),
+            ModItems.LOOM_TABLE.get(),
+            ModItems.MASON_TABLE.get(),
+            ModItems.ALCHEMY_BENCH.get(),
+            ModItems.TINKERING_TABLE.get()
+        );
     }
 }

--- a/common/src/main/java/earth/terrarium/chipped/common/compat/jei/WorkbenchCategory.java
+++ b/common/src/main/java/earth/terrarium/chipped/common/compat/jei/WorkbenchCategory.java
@@ -3,45 +3,54 @@ package earth.terrarium.chipped.common.compat.jei;
 import earth.terrarium.chipped.Chipped;
 import earth.terrarium.chipped.common.registry.ModItems;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
-import mezz.jei.api.gui.drawable.IDrawable;
+import mezz.jei.api.gui.ingredient.IRecipeSlotDrawable;
+import mezz.jei.api.gui.placement.HorizontalAlignment;
+import mezz.jei.api.gui.placement.VerticalAlignment;
+import mezz.jei.api.gui.widgets.IRecipeExtrasBuilder;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
-import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.recipe.category.AbstractRecipeCategory;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
-public record WorkbenchCategory(IGuiHelper guiHelper) implements IRecipeCategory<Ingredient> {
+import java.util.List;
+
+public class WorkbenchCategory extends AbstractRecipeCategory<Ingredient> {
     public static final ResourceLocation ID = ResourceLocation.fromNamespaceAndPath(Chipped.MOD_ID, "workbench");
     public static final RecipeType<Ingredient> RECIPE = new RecipeType<>(ID, Ingredient.class);
 
-    private static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath("jei", "textures/jei/gui/gui_vanilla.png");
-
-    @Override
-    public RecipeType<Ingredient> getRecipeType() {
-        return RECIPE;
-    }
-
-    @Override
-    public Component getTitle() {
-        return Component.translatable("container.chipped.workbench");
-    }
-
-    @Override
-    public IDrawable getBackground() {
-        return guiHelper.createDrawable(TEXTURE, 0, 220, 82, 34);
-    }
-
-    @Override
-    public IDrawable getIcon() {
-        return guiHelper.createDrawableItemStack(ModItems.MASON_TABLE.get().getDefaultInstance());
+    public WorkbenchCategory(IGuiHelper guiHelper) {
+        super(
+            RECIPE,
+            Component.translatable("container.chipped.workbench"),
+            guiHelper.createDrawableItemLike(ModItems.MASON_TABLE.get()),
+            142,
+            110
+        );
     }
 
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, Ingredient recipe, IFocusGroup focuses) {
-        builder.addSlot(RecipeIngredientRole.INPUT, 1, 9).addIngredients(recipe);
-        builder.addSlot(RecipeIngredientRole.OUTPUT, 61, 9).addIngredients(recipe);
+        builder.addInputSlot(6, 9)
+            .setStandardSlotBackground()
+            .setPosition(0, 0, getWidth(), getHeight(), HorizontalAlignment.CENTER, VerticalAlignment.TOP)
+            .addIngredients(recipe);
+
+        for (ItemStack stack : recipe.getItems()) {
+            builder.addOutputSlot()
+                .addItemStack(stack);
+        }
+    }
+
+    @Override
+    public void createRecipeExtras(IRecipeExtrasBuilder builder, Ingredient recipe, IFocusGroup focuses) {
+        List<IRecipeSlotDrawable> outputs = builder.getRecipeSlots().getSlots(RecipeIngredientRole.OUTPUT);
+
+        builder.addScrollGridWidget(outputs, 7, 5)
+            .setPosition(0, 0, getWidth(), getHeight(), HorizontalAlignment.CENTER, VerticalAlignment.BOTTOM);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@ parchmentVersion=2024.07.28
 
 modMenuVersion=11.0.2
 reiVersion=16.0.754
-jeiVersion=19.14.2.147
+# jei versions: https://github.com/mezz/JustEnoughItems#1211
+jeiVersion=19.19.3.224
 
 resourcefulLibVersion=3.0.9
 athenaVersion=4.0.1

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -44,3 +44,10 @@ type="required"
 versionRange = "[4.0.0,)"
 ordering = "NONE"
 side = "CLIENT"
+
+[[dependencies.chipped]]
+modId = "jei"
+type="optional"
+versionRange = "[19.19.3,)"
+ordering = "NONE"
+side = "CLIENT"


### PR DESCRIPTION
Closes https://github.com/terrarium-earth/Chipped/issues/341 (once backported to 1.20.1)
Closes https://github.com/mezz/JustEnoughItems/issues/3777

This PR updates JEI to the latest version, and improves the recipe display with the new ingredient grid feature.

![Screenshot 2024-10-01 at 3 19 58 PM](https://github.com/user-attachments/assets/2fae8634-71fd-454b-be53-465e39c9a83e)
![Screenshot 2024-10-01 at 3 21 50 PM](https://github.com/user-attachments/assets/49d74536-2f86-42d2-a12c-52e8db5b2aa3)
![Screenshot 2024-10-01 at 3 24 26 PM](https://github.com/user-attachments/assets/d26b8aaa-2d71-4782-a965-7837d92fb302)

Hopefully this will make it easier for players to find what they're looking for!