### PR TITLE
Fix duplication bug when item in selected slot changes after being selected

### DIFF
--- a/common/src/main/java/earth/terrarium/chipped/common/menus/WorkbenchMenu.java
+++ b/common/src/main/java/earth/terrarium/chipped/common/menus/WorkbenchMenu.java
@@ -110,7 +110,7 @@ public class WorkbenchMenu extends AbstractContainerMenu {
     }
 
     public void craft(ItemStack stack, boolean replaceAll) {
-        if (stack.isEmpty()) return;
+        if (stack.isEmpty() || getSlot(selectedStackId).getItem() != stack) return;
 
         boolean canCraft = false;
         for (var result : results) {


### PR DESCRIPTION
Fixes #400 by checking if the item in the selected slot is the same as the item being used for crafting.